### PR TITLE
debian/control: Moved build dependencies and wrap-and-sort

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,13 @@ Source: fahcontrol
 Section: science
 Priority: optional
 Maintainer: Braiam Peguero <braiamp@gmail.com>
-Build-Depends:
- debhelper (>= 9)
- , debhelper (>= 9.20160709) | dh-systemd
- , dh-python
- , python3
- , python3-setuptools
+Build-Depends: debhelper (>= 9),
+               debhelper (>= 9.20160709) | dh-systemd,
+               dh-python,
+               gir1.2-gtk-3.0,
+               python3,
+               python3-gi,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://foldingathome.org/
 Vcs-Git: https://github.com/FoldingAtHome/fah-control.git
@@ -16,9 +17,7 @@ Rules-Requires-Root: no
 
 Package: fahcontrol
 Architecture: all
-Depends: python3-gi
- , ${python3:Depends}
- , ${misc:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}
 Suggests: fahclient, fahviewer
 Description: Folding@home Client Control
  Folding@home is a distributed computing project using volunteered


### PR DESCRIPTION
python3-gi is needed as build dependency. I'm unsure if these packages are available in Ubuntu 20.04.

There are still lintian unresolved warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cdberkstresser/fah-control/12)
<!-- Reviewable:end -->
