### PR TITLE
Fix PyON JSON parsing and exception string formatting.

### DIFF
--- a/fah/Connection.py
+++ b/fah/Connection.py
@@ -215,7 +215,7 @@ class Connection:
             self.last_message = time.time()
         except Exception as e:
             print('ERROR parsing PyON message: %s: %s'
-                  % (str(e), data.encode('string_escape')))
+                  % (str(e), data.encode('unicode_escape')))
 
     def parse(self):
         start = self.readBuf.find('\nPyON ')
@@ -228,7 +228,7 @@ class Connection:
                 if len(tokens) < 3:
                     self.readBuf = self.readBuf[eol:]
                     raise Exception('Invalid PyON line: ' +
-                                    line.encode('string_escape'))
+                                    line.encode('unicode_escape'))
 
                 version = int(tokens[1])
                 type = tokens[2]

--- a/fah/util/PYONDecoder.py
+++ b/fah/util/PYONDecoder.py
@@ -182,7 +182,7 @@ def make_pyon_scanner(context):
 
     if nextchar == '"': return parse_string(string, idx + 1, 'utf-8', strict)
     elif nextchar == '{':
-      return parse_object((string, idx + 1), 'utf-8', strict, scan_once,
+      return parse_object((string, idx + 1), strict, scan_once,
                           object_hook, object_pairs_hook)
     elif nextchar == '[':
       return parse_array((string, idx + 1), scan_once)


### PR DESCRIPTION
Small fix to the client message parser, otherwise can't parse any incoming data. Exception formatting also didn't work properly as Python3 changed `string_escape` encoding to `unicode_escape`.