### PR TITLE
Update dependencies in README, add python-six

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,19 @@ See: https://foldingathome.org/
 
 ## Debian / Ubuntu
 
-    sudo apt-get install -y python3-stdeb python3-gi python3-all debhelper \
+    sudo apt-get install -y python3-stdeb python3-gi python3-all python3-six debhelper \
       dh-python gir1.2-gtk-3.0
 
 ## RedHat / CentOS
 
-    sudo yum install -y python3-gobject
+    sudo yum install -y python3-gobject python3-six
+    
+## Arch Linux / Manjaro
+
+    sudo pacman -S python python-setuptools python-gobject python-six
+    
+Alternatively, use the unofficial [AUR package](https://aur.archlinux.org/packages/fahcontrol/) (or [this one for the GTK3/Python3 fork](https://aur.archlinux.org/packages/fahcontrol-gtk3-git)
 
 ## Windows (MinGW in MSYS2)
 
-    pacman -S mingw-w64-x86_64-{gtk3,python3-{cx_Freeze,gobject}}
+    pacman -S mingw-w64-x86_64-{gtk3,python-{cx_Freeze,gobject,six}}


### PR DESCRIPTION
[I've been told](https://aur.archlinux.org/packages/fahcontrol-gtk3-git/#comment-784981) that this fork depends on `python-six`, apparently thanks to `util/PYONDecoder`.

Consider either updating the README to reflect this, or removing the `python-six` dependency (That library is intended only for Python 2 compatibility, and I'm guessing this project won't need that anymore...)