### PR TITLE
Change module to import 'MutableMapping' variable

### DIFF
--- a/fah/util/OrderedDict.py
+++ b/fah/util/OrderedDict.py
@@ -20,7 +20,7 @@
 ################################################################################
 
 from collections import UserDict
-from collections import MutableMapping as DictMixin
+from collections.abc import MutableMapping as DictMixin
 
 class OrderedDict(dict, DictMixin):
 


### PR DESCRIPTION
Quick fix for 'collections' module to 'collections.abc' module to use 'MutableMappings'. #22 